### PR TITLE
Removed unnecessary appending of current path

### DIFF
--- a/run_it_on_condor.sh
+++ b/run_it_on_condor.sh
@@ -42,7 +42,6 @@ arguments=( "$@" )
 
 # Get path from which this script was called
 BASH_SCRIPT_DIR=$(pwd)
-bash_script_path=${BASH_SCRIPT_DIR}/${bash_script_name}
 
 # Create temporary submit file and starter file that does setup
 date_base="$(date +%Y%m%d%H%M%S%N)"
@@ -56,7 +55,7 @@ chmod u+x ${starter_file_path}
 local_dir_line_number=5
 sed -i "${local_dir_line_number}s\.*\ cd ${BASH_SCRIPT_DIR}\  " ${starter_file_path}
 executable_line_number=7
-sed -i "${executable_line_number}s\.*\ ${bash_script_path} $arguments \  " ${starter_file_path}
+sed -i "${executable_line_number}s\.*\ ${bash_script_name} $arguments \  " ${starter_file_path}
 starter_line_number=12
 starter_line_string="Executable = ${starter_file_path}"
 sed -i "${starter_line_number}s\.*\ ${starter_line_string} \  " ${submit_file_path}


### PR DESCRIPTION
Removed that current directory is appended in front of script name for
starter script. No longer needed since starter script changes to current
directory, and harmful because it prohibits usage of absolute script
paths.